### PR TITLE
Default rtp input protocol in http-api

### DIFF
--- a/src/content/docs/http-api/inputs/rtp.mdx
+++ b/src/content/docs/http-api/inputs/rtp.mdx
@@ -72,6 +72,7 @@ range will be returned from [`register-input` request](/http-api/routes#register
 Transport protocol.
 
 - **Type**: `"udp" | "tcp_server"`
+- **Default value**: `udp`
 - **Supported values**:
   - `udp` - UDP protocol.
   - `tcp_server` - TCP protocol where Smelter is the server side of the connection.


### PR DESCRIPTION
Added missing info about default protocol in rtp streaming to input