### PR TITLE
Point demo links to smelter-labs/examples

### DIFF
--- a/src/content/docs/fundamentals/setup-choices.mdx
+++ b/src/content/docs/fundamentals/setup-choices.mdx
@@ -59,7 +59,7 @@ Trade-offs and limitations:
 ### TypeScript SDK (Browser)
 
 Use `@swmansion/smelter-web-client` NPM package (that runs in the browser) to manage Smelter instance running on the server.
-Check out this [example Vite project](https://github.com/software-mansion/smelter/tree/master/demos/vite-web-client) to get started.
+Check out this [example Vite project](https://github.com/smelter-labs/examples/tree/main/vite-web-client) to get started.
 
 
 In this approach:
@@ -82,7 +82,7 @@ Trade-offs and limitations:
 ### TypeScript SDK + WASM
 
 Use `@swmansion/smelter-web-wasm` package to run Smelter inside the browser. Check out this
-[example Vite project](https://github.com/software-mansion/smelter/tree/master/demos/vite-web-wasm) 
+[example Vite project](https://github.com/smelter-labs/examples/tree/main/vite-web-wasm) 
 to get started.
 
 In this approach:

--- a/src/content/docs/ts-sdk/configuration.mdx
+++ b/src/content/docs/ts-sdk/configuration.mdx
@@ -93,7 +93,7 @@ is done fully in-browser by Smelter code compiled to WASM.
 
 ### Configuration
 
-In the Smelter repository you can find [few example projects](https://github.com/software-mansion/smelter/tree/master/demos) with Smelter configured.
+In the Smelter repository you can find [few example projects](https://github.com/smelter-labs/examples) with Smelter configured.
 
 We are working on examples of other configurations, but here are steps you need to follow
 to configure that yourself:

--- a/src/content/docs/ts-sdk/guides/quick-start-wasm.mdx
+++ b/src/content/docs/ts-sdk/guides/quick-start-wasm.mdx
@@ -15,7 +15,7 @@ This is a simplified example, it does not handle a cleanup, double mount in stri
 race conditions between initialization and starting certain actions. This is not specific
 to Smelter itself, so to keep this example clean we will not focus on that in this guide.
 
-For a more complete, production ready examples check out our [demo applications](https://github.com/software-mansion/smelter/tree/master/demos).
+For a more complete, production ready examples check out our [demo applications](https://github.com/smelter-labs/examples).
 </Aside>
 
 <Steps>

--- a/src/content/docs/ts-sdk/web-wasm/overview.mdx
+++ b/src/content/docs/ts-sdk/web-wasm/overview.mdx
@@ -61,7 +61,7 @@ Check out [`Smelter` documentation](/ts-sdk/web-wasm/smelter).
 
 ### Configuration
 
-In the Smelter repository you can find [few example projects](https://github.com/software-mansion/smelter/tree/master/demos) with Smelter configured.
+In the Smelter repository you can find [few example projects](https://github.com/smelter-labs/examples) with Smelter configured.
 
 We are working on examples of other configurations, but here are steps you need to follow
 to configure that yourself:

--- a/src/content/docs/versions/ts-sdk/0.2.x/configuration.mdx
+++ b/src/content/docs/versions/ts-sdk/0.2.x/configuration.mdx
@@ -98,7 +98,7 @@ is done fully in-browser by Smelter code compiled to WASM.
 
 ### Configuration
 
-In the Smelter repository you can find [few example projects](https://github.com/software-mansion/smelter/tree/master/demos) with Smelter configured.
+In the Smelter repository you can find [few example projects](https://github.com/smelter-labs/examples) with Smelter configured.
 
 We are working on examples of other configurations, but here are steps you need to follow
 to configure that yourself:

--- a/src/content/docs/versions/ts-sdk/0.2.x/guides/quick-start-wasm.mdx
+++ b/src/content/docs/versions/ts-sdk/0.2.x/guides/quick-start-wasm.mdx
@@ -17,7 +17,7 @@ WebRTC (via WHIP protocol).
   race condition between initialization and starting certain actions. This is not specific
   to Smelter itself, so to keep this example clean we will not focus on that in this guide.
 
-  For a more complete, production ready examples checkout our [demo applications](https://github.com/software-mansion/smelter/tree/master/demos).
+  For a more complete, production ready examples checkout our [demo applications](https://github.com/smelter-labs/examples).
 </Aside>
 
 <Steps>

--- a/src/content/docs/versions/ts-sdk/0.3.x/configuration.mdx
+++ b/src/content/docs/versions/ts-sdk/0.3.x/configuration.mdx
@@ -98,7 +98,7 @@ is done fully in-browser by Smelter code compiled to WASM.
 
 ### Configuration
 
-In the Smelter repository you can find [few example projects](https://github.com/software-mansion/smelter/tree/master/demos) with Smelter configured.
+In the Smelter repository you can find [few example projects](https://github.com/smelter-labs/examples) with Smelter configured.
 
 We are working on examples of other configurations, but here are steps you need to follow
 to configure that yourself:

--- a/src/content/docs/versions/ts-sdk/0.3.x/guides/quick-start-wasm.mdx
+++ b/src/content/docs/versions/ts-sdk/0.3.x/guides/quick-start-wasm.mdx
@@ -17,7 +17,7 @@ WebRTC (via WHIP protocol).
   race conditions between initialization and starting certain actions. This is not specific
   to Smelter itself, so to keep this example clean we will not focus on that in this guide.
 
-  For a more complete, production ready examples check out our [demo applications](https://github.com/software-mansion/smelter/tree/master/demos).
+  For a more complete, production ready examples check out our [demo applications](https://github.com/smelter-labs/examples).
 </Aside>
 
 <Steps>

--- a/src/content/docs/versions/ts-sdk/0.3.x/web-wasm/overview.mdx
+++ b/src/content/docs/versions/ts-sdk/0.3.x/web-wasm/overview.mdx
@@ -68,7 +68,7 @@ Check out [`Smelter` documentation](/ts-sdk/0.3.x/web-wasm/smelter).
 
 ### Configuration
 
-In the Smelter repository you can find [few example projects](https://github.com/software-mansion/smelter/tree/master/demos) with Smelter configured.
+In the Smelter repository you can find [few example projects](https://github.com/smelter-labs/examples) with Smelter configured.
 
 We are working on examples of other configurations, but here are steps you need to follow
 to configure that yourself:


### PR DESCRIPTION
## Summary
- Update all references to `software-mansion/smelter/tree/master/demos` to point to the new `smelter-labs/examples` repo
- Deep links remapped: `vite-web-client` and `vite-web-wasm` paths preserved under the new repo root
- Versioned snapshots (0.2.x, 0.3.x) updated too since the old URLs are now broken

## Test plan
- [ ] Verify the new links resolve (root + `vite-web-client` + `vite-web-wasm`)
- [ ] Run `ENABLE_LINK_CHECKER=1 pnpm build` locally to confirm no broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)